### PR TITLE
Add Direct AD Integration guide

### DIFF
--- a/src/contents.rst
+++ b/src/contents.rst
@@ -23,6 +23,8 @@ Table of Contents
    docs/quick-start
    docs/introduction
    docs/reporting-bugs
+   docs/direct-ad.rst
+   docs/manual-ad.rst
 
 .. toctree::
    :caption: Troubleshooting

--- a/src/docs/direct-ad.rst
+++ b/src/docs/direct-ad.rst
@@ -1,0 +1,116 @@
+Direct AD Integration
+#####################
+
+This page describes how to configure SSSD to authenticate with a Windows 2008 or later Domain Server using the Active Directory provider (``id_provider=ad``). The AD provider was introduced with SSSD 1.9.0. Follow :doc:`manual-ad` to join AD manually without realmd.
+
+Joining the GNU/Linux client using realmd (Recommended)
+*******************************************************
+
+The realmd (Realm Discovery) project is a system service that manages discovery and enrolment to several centralized domains including AD or IPA. realmd is included in several popular GNU/Linux distributions including:
+
+* Red Hat Enterprise Linux 7.0 and later
+* Fedora 19 and later
+* Ubuntu 13.04 and later
+* Debian 8.0 and later
+
+Run ``realm discover`` to see what domains realmd can find. Note that this functionality relies on NetworkManager being up and running in order to read the DHCP domain:
+
+.. code-block:: bash
+
+    realm discover
+    realm discover AD.EXAMPLE.COM
+
+Finally, joining the Active Directory domain is as easy as:
+
+.. code-block:: bash
+
+    realm join AD.EXAMPLE.COM
+
+You will be prompted for Administrator password. However, realmd supports more enrolment options, including using a one-time password or selecting a custom OU. Refer to the `realmd documentation <https://www.freedesktop.org/software/realmd/docs/>`_ for more details.
+
+Note that the ``realm permit`` command configures the simple access provider.
+
+Additional reading
+******************
+
+The following sections are optional reading, it contains information which may be useful to administrators using SSSD with the AD Provider.
+
+Testing with a clean cache
+==========================
+
+You may have made iterative changes to your setup while learning about SSSD. To make sure that your setup actually works, and you're not relying on cached credentials, or cached LDAP information, you may want to clear out the local cache. Obviously this will erase local credentials, and all cached user information, so you should only do this for testing, and while on the network with network access to the AD servers:
+
+.. code-block:: bash
+
+    sssctl cache-remove
+    getent passwd administrator@ad.example.com
+
+If all looks well on your system after this, you know that sssd is able to use the kerberos and ldap services you've configured.
+
+Configuring Active Directory to use POSIX attributes
+====================================================
+
+The Active Directory provider is able to either map the Windows Security Identifiers (SIDs) into POSIX IDs or use the POSIX IDs that are set on the AD server. By default, the AD provider uses the automatic ID mapping method. In order to use the POSIX IDs, you need to set up `Identity Management for UNIX <https://technet.microsoft.com/en-us/library/cc731178.aspx>`_. Note that starting with Windows Server 2016, the `Identity Management for UNIX UI is deprecated <https://blogs.technet.microsoft.com/activedirectoryua/2016/02/09/identity-management-for-unix-idmu-is-deprecated-in-windows-server/>`_. However, it is still possible to set the POSIX attributes. For managing POSIX attributes in environments with IPA-AD trusts (Indirect AD integration) deployed, the `ID views <https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/id-views.html>`_ feature of IDM might also be interesting.
+
+When working with multiple trusted domains, SSSD often reads the data from the Global Catalog first. However, POSIX attributes such as UIDs or GIDs are not replicated to the Global Catalog by default. For performance reasons, it might be a good idea to set them to be replicated manually. This recommendation applies to setups that do not use automatic ID mapping and use ``ldap_id_mapping=False`` instead.
+
+* Install the Identity Management for UNIX Components
+
+  * Follow this `technet article <https://technet.microsoft.com/en-us/library/cc731178.aspx>`_ to install Identity Management for UNIX on primary and child domains controllers
+  * After the installation has finished, you'll be able to assign POSIX UID, GID and other attributes using a tab called UNIX Attributes in the Properties menu
+* Add Schema Snap-in
+
+  * To enable new attributes to replicate to the GC we need an Active Directory Schema snap-in. Use `these steps <https://serverfault.com/questions/609592/where-is-active-directory-snap-in-for-server-2012-r2>`_ to install the Schema Snap-In if you are having trouble.
+* Modify Attributes for replication
+
+  * The `article <https://docs.microsoft.com/en-us/windows/win32/ad/attributes-included-in-the-global-catalog>`_ explains how to select any attribute for replication
+  * In our case, select ``uidNumber``, ``gidNumber``, ``unixHomeDirectory`` and ``loginShell``
+* Verifying Attributes replication to Global Catalog
+
+  * In general, search for a user entry that has the POSIX attributes set on port 3268 of a Domain Controller
+  * You can use the Windows ``LDP`` tool or after the GNU/Linux machine is joined, simply ``ldapsearch``
+
+DNS validation
+==============
+
+It is recommended that the GNU/Linux client you are enrolling is able to resolve the SRV records the Active directory publishes. In order to do so, the clients would typically point at the AD DCs in ``/etc/resolv.conf``. You can verify this using dig:
+
+.. code-block:: bash
+
+    dig -t SRV _ldap._tcp.ad.example.com @server.ad.example.com
+
+Unreachable AD servers/domains
+==============================
+
+If any DNS-advertised (see dig command above) AD servers are unreachable (usually for firewall reasons), you need to list the reachable servers using the ``ad_server`` configuration option. The same is true for AD domains, SSSD auto-discovers all domains in the forest by default, so if any of the DCs in other domains are not reachable, either exclude that domain with ``ad_enabled_domains`` or, if only some DCs from that trusted domain are reachable, define a per-subdomain section in the config file (see below for an example).
+
+Fully qualified names
+=====================
+The AD provider sets the option ``use_fully_qualified_names`` to false, manually setting this option to ``true`` forces all lookups to contain the domain name as well, either the full domain name as specified in sssd.conf (``getent passwd administrator@ad.example.com``) or the short NetBIOS name (``getent passwd AD\\Administrator``). This restriction helps separate users from different domains, especially in setups with multiple domains in a trusted environment, or in cases where local UNIX users might have the same user names as AD users.
+
+Access control options
+======================
+
+There is a number of access control options available to a directly-enrolled AD client machine.
+
++----------------+---------------------------+-------------------------------------------------------+-------------------------------------------------------------------------------+
+| access provider| simple                    | ad                                                    | ad_access_filter                                                              |
++================+===========================+=======================================================+===============================================================================+
+| Pros           | Very simple,              | Supports fully centralized environments by using GPOs | Very expressive,                                                              |
+|                | supports nested groups    |                                                       | can be used to allow/deny based on any properties of the LDAP user object.    |
++----------------+---------------------------+-------------------------------------------------------+-------------------------------------------------------------------------------+
+| Cons           | Only supports allow/deny  | Not supported with older releases,                    | Cumbersome to write                                                           |
+|                | user or group             | may not be desirable in a mixed GNU/Linux and         |                                                                               |
+|                |                           | Windows environment                                   |                                                                               |
++----------------+---------------------------+-------------------------------------------------------+-------------------------------------------------------------------------------+
+
+It is also possible to use completely external means of access control, such as ``pam_access.so``. Those might be useful when supporting legacy stack alongside SSSD or when defining access control by means SSSD doesn't support (such as per netgroup).
+
+Other documentation
+===================
+
+Red Hat maintains a very in-depth `guide about SSSD and Windows integration <https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Windows_Integration_Guide/index.html>`_. Some of the commands such as setting up the PAM stack or installing packages are specific to RHEL, CentOS or Fedora, but the general information are useful for all distributions.
+
+See the `following article on Technet site <http://technet.microsoft.com/en-us/library/cc772815%28WS.10%29.aspx>`_ for more in-depth Kerberos understanding
+
+If there is a specific document for your distribution or environment, such as the RHEL guide below, please let us know so that we can include it\!

--- a/src/docs/manual-ad.rst
+++ b/src/docs/manual-ad.rst
@@ -1,0 +1,304 @@
+Manual Active Directory Join
+##############################################
+
+Joining the GNU/Linux client to the AD domain manually
+******************************************************
+
+The manual process of joining the GNU/Linux client to the AD domain consists of several steps:
+
+* Acquiring the host keytab with Samba or create it using ``ktpass`` on the AD controller
+* Configuring ``sssd.conf``
+* Configuring the system to use the SSSD for identity information and authentication
+
+Creating Host Keytab with Samba
+*******************************
+
+On the GNU/Linux client with properly configured ``/etc/krb5.conf`` (see below) and suitable ``/etc/samba/smb.conf``, replacing your REALM/Domain name:
+
+.. code-block:: ini
+   :caption: /etc/krb5.conf
+
+    [logging]
+    default = FILE:/var/log/krb5libs.log
+
+    [libdefaults]
+    default_realm = AD.EXAMPLE.COM
+    dns_lookup_realm = true
+    dns_lookup_kdc = true
+    ticket_lifetime = 24h
+    renew_lifetime = 7d
+    forwardable = true
+    rdns = false
+
+    # You may also want either of:
+    # allow_weak_crypto = true
+    # default_tkt_enctypes = arcfour-hmac
+
+    [realms]
+    # Define only if DNS lookups are not working
+    # AD.EXAMPLE.COM = {
+    # kdc = server.ad.example.com
+    # master_kdc = server.ad.example.com
+    # admin_server = server.ad.example.com
+    # }
+
+    [domain_realm]
+    # Define only if DNS lookups are not working
+    # .ad.example.com = AD.EXAMPLE.COM
+    # ad.example.com = AD.EXAMPLE.COM
+
+Make sure ``kinit aduser@AD.EXAMPLE.COM`` works properly. If not, using ``KRB5_TRACE`` usually provides helpful information:
+
+.. code-block:: bash
+
+    KRB5_TRACE=/dev/stdout kinit -V aduser@AD.EXAMPLE.COM.
+
+Update ``/etc/samba/smb.conf``, replacing the sample domain/realm name with yours:
+
+.. code-block:: ini
+   :caption: /etc/samba/smb.conf
+
+    [global]
+    security = ads
+    realm = AD.EXAMPLE.COM
+    workgroup = EXAMPLE
+
+    log file = /var/log/samba/%m.log
+
+    kerberos method = secrets and keytab
+
+    client signing = yes
+    client use spnego = yes
+
+Now join the client with:
+
+.. code-block:: bash
+
+    kinit Administrator
+    net ads join -k
+
+Alternatively, without using the Kerberos ticket:
+
+.. code-block:: bash
+
+    net ads join -U Administrator
+
+Additional principals can be created later with ``net ads keytab add`` if needed.
+
+You don't need a Domain Administrator account to do this, you just need an account with sufficient rights to join a machine to the domain. This is a notable advantage of this approach over generating the keytab directly on the AD controller.
+
+Creating Service Keytab on AD
+*****************************
+
+Do not do this step if you've already created a keytab using Samba. This part of the guide might be useful if the password for Administrator or another user who is able to enroll computers can't be shared.
+
+On the Windows server:
+
+* Open Users & Computers snap-in
+* Create a new Computer object named ``client`` (i.e., the name of the host running SSSD)
+* On the command prompt
+
+.. code-block:: bash
+
+    setspn -A host/client.ad.example.com@AD.EXAMPLE.COM client
+    setspn -L client
+    ktpass /princ host/client.ad.example.com@AD.EXAMPLE.COM /out client-host.keytab /crypto all
+    /ptype KRB5_NT_PRINCIPAL -desonly /mapuser AD\client$ +setupn +rndPass +setpass +answer
+
+* This sets the machine account password and UPN for the principal
+* If you create additional keytabs for the host add ``-setpass -setupn`` for the above command to prevent resetting the machine password (thus changing kvno) and to prevent overwriting the UPN
+* Transfer the keytab created in a secure manner to the client as ``/etc/krb5.keytab`` and make sure its permissions are correct:
+
+.. code-block:: bash
+
+    chown root:root /etc/krb5.keytab
+    chmod 0600 /etc/krb5.keytab
+    restorecon /etc/krb5.keytab
+
+See the next section for verifying the keytab file and the example ``sssd.conf`` below for the needed SSSD configuration.
+
+Pre-flight check
+****************
+
+To verify the keytab was acquired correctly and can be used to access AD:
+
+.. code-block:: bash
+
+    net ads join -U Administrator
+
+    klist -ke
+    kinit -k CLIENT\$@AD.EXAMPLE.COM
+
+Now using this credential you've just created try fetching data from the server with ``ldapsearch`` (in case of issues make sure ``/etc/openldap/ldap.conf`` does not contain any unwanted settings):
+
+.. code-block:: bash
+
+    net ads join -U Administrator
+
+    /usr/bin/ldapsearch -H ldap://server.ad.example.com/ -Y GSSAPI -N -b "dc=ad,dc=example,dc=com"
+    "(&(objectClass=user)(sAMAccountName=aduser))"
+
+By using the credential from the keytab, you've verified that this credential has sufficient rights to retrieve user information.
+
+You can also check if searching the Global Catalog works and whether the attributes your environment depends on are replicated to the Global Catalog:
+
+.. code-block:: bash
+
+    net ads join -U Administrator
+
+    /usr/bin/ldapsearch -H ldap://server.ad.example.com:3268 -Y GSSAPI -N -b "dc=ad,dc=example,dc=com"
+    "(&(objectClass=user)(sAMAccountName=aduser))"
+
+After both ``kinit`` and ``ldapsearch`` work properly proceed to actual SSSD configuration.
+
+SSSD setup
+**********
+
+Configuring SSSD consists of several steps:
+
+* Install the ``sssd-ad`` package on the GNU/Linux client machine
+* Make configuration changes to the files below
+* Start the ``sssd`` service
+
+Copy the following sssd.conf, additional options can be added as needed
+
+.. code-block:: ini
+   :caption: /etc/sssd/sssd.conf
+
+    [sssd]
+    config_file_version = 2
+    domains = ad.example.com
+    services = nss, pam
+
+    [domain/ad.example.com]
+    # Uncomment if you need offline logins
+    # cache_credentials = true
+
+    id_provider = ad
+    auth_provider = ad
+    access_provider = ad
+
+    # Uncomment if service discovery is not working
+    # ad_server = server.ad.example.com
+
+    # Uncomment if you want to use POSIX UIDs and GIDs set on the AD side
+    # ldap_id_mapping = False
+
+    # Uncomment if the trusted domains are not reachable
+    #ad_enabled_domains = ad.example.com
+
+    # Comment out if the users have the shell and home dir set on the AD side
+    default_shell = /bin/bash
+    fallback_homedir = /home/%d/%u
+
+    # Uncomment and adjust if the default principal SHORTNAME$@REALM is not available
+    # ldap_sasl_authid = host/client.ad.example.com@AD.EXAMPLE.COM
+
+    # Comment out if you prefer to use shortnames.
+    use_fully_qualified_names = True
+
+    # Uncomment if the child domain is reachable, but only using a specific DC
+    # [domain/ad.example.com/child.example.com]
+    # ad_server = dc.child.example.com
+
+Set the file ownership and permissions
+
+.. code-block:: bash
+
+    chown root:root /etc/sssd/sssd.conf
+    chmod 0600 /etc/sssd/sssd.conf
+    restorecon /etc/sssd/sssd.conf
+
+NSS/PAM Configuration
+*********************
+
+Depending on your distribution you have different options how to enable SSSD.
+
+.. code-tabs::
+    :caption: Configure identity/authentication files
+
+    .. fedora-tab::
+
+        dnf install oddjob-mkhomedir
+        authselect select sssd with-mkhomedir
+        systemctl enable --now oddjobd.service
+
+    .. rhel-tab::
+
+        dnf install oddjob-mkhomedir
+        authselect select sssd with-mkhomedir
+        systemctl enable --now oddjobd.service
+
+    .. ubuntu-tab::
+
+        apt install libnss-sss libpam-sss
+
+On Debian/Ubuntu, add ``pam_mkhomedir.so`` to the PAM session configuration manually and restart SSSD.
+
+Configure NSS/PAM manually
+--------------------------
+
+Manual configuration can be done with the following changes. The file paths for PAM in the example below are from Debian/Ubuntu, in Fedora/RHEL corresponding manual configuration should be done in ``/etc/pam.d/system-auth`` and ``/etc/pam.d/password-auth``. See the sample
+nsswitch.conf below, it is expected to contain other modules.
+
+.. code-block:: nsswitch
+   :caption: /etc/nsswitch.conf
+
+    passwd: files sss
+    shadow: files sss
+    group: files sss
+
+    hosts: files dns
+
+    bootparams: files
+
+    ethers: files
+    netmasks: files
+    networks: files
+    protocols: files
+    rpc: files
+    services: files sss
+
+    netgroup: files sss
+
+    publickey: files
+
+    automount: files sss
+    aliases: files
+    sudoers : files sss
+
+
+in the ``/etc/pam.d/common-auth file``, Right after the ``pam_unix.so`` line, add:
+
+.. code-block:: pam
+   :caption: /etc/pam.d/common-auth
+
+    auth sufficient pam_sss.so use_first_pass
+
+in the ``/etc/pam.d/common-account`` file, Right after the ``pam_unix.so`` line, add:
+
+.. code-block:: pam
+   :caption: /etc/pam.d/common-account
+
+    account [default=bad success=ok user_unknown=ignore] pam_sss.so
+
+in the ``/etc/pam.d/common-password`` file, Right after the ``pam_unix.so`` line, add:
+
+.. code-block:: pam
+   :caption: /etc/pam.d/common-password
+
+    password sufficient pam_sss.so use_authtok
+
+In the ``/etc/pam.d/common-session`` file. Just before the ``pam_unix.so`` line, add:
+
+.. code-block:: pam
+   :caption: /etc/pam.d/common-session
+
+    session optional pam_mkhomedir.so
+
+Also in this file right after the ``pam_unix.so`` line, add:
+
+.. code-block:: pam
+   :caption: /etc/pam.d/common-session
+
+    session optional pam_sss.so


### PR DESCRIPTION
Reorganized and updated the Direct Windows Integration guide to be more concise, some of the notable changes:

  * Emphasizing realm join as the preferred, and first recommended join method.
  * Added a section `Unreachable AD servers/domains` to highlight `ad_enabled_domains` and `ad_server` configuration options as this is a common problem from my experience.
  * Separated out ``Manually Active Directory Join`` to its own document, do we still want to keep this?
  * A couple links in `Configuring Active Directory to use POSIX attributes` were no longer valid, replacement articles I  found may not be as useful.