### PR TITLE
CI: update configured sources for package management

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
+        sudo apt-get update -y
         sudo apt-get install graphviz plantuml
         pip3 install virtualenv
         virtualenv .venv


### PR DESCRIPTION
https://github.com/SSSD/sssd.io/pull/65 is failing due to old sources.