### PR TITLE
Fix release year in releases.rst

### DIFF
--- a/src/releases.rst
+++ b/src/releases.rst
@@ -9,11 +9,11 @@ SSSD Releases
 .. releases::
 
     .. release:: sssd-2.9.1
-        :date: 2022-06-23
+        :date: 2023-06-23
         :download: https://github.com/SSSD/sssd/releases/tag/2.9.1
 
     .. release:: sssd-2.9.0
-        :date: 2022-05-05
+        :date: 2023-05-05
         :download: https://github.com/SSSD/sssd/releases/tag/2.9.0
 
     .. release:: sssd-2.8.2


### PR DESCRIPTION
releases: Fix release year from 2022 to 2023 for SSSD 2.9.0 and SSSD 2.9.1 versions
Resolves: https://github.com/SSSD/sssd/issues/6858