### PR TITLE
contrib: add supported versions

### DIFF
--- a/src/community.rst
+++ b/src/community.rst
@@ -35,6 +35,10 @@ Community
 
     Have you found a bug in SSSD? Please report it in our `issue tracker`_.
 
+    Please check `SECURITY.md <https://github.com/SSSD/sssd/blob/master/SECURITY.md>`_
+    on SSSD's `project page <https://github.com/SSSD/sssd>`_
+    how to report security issues.
+
 .. _issue tracker: https://github.com/SSSD/sssd/issues
 
 

--- a/src/releases.rst
+++ b/src/releases.rst
@@ -1,5 +1,9 @@
 :orphan:
 
+SSSD Supported Versions
+#######################
+- **sssd-2.13**
+
 SSSD Releases
 #############
 


### PR DESCRIPTION
Add the currently supported versions of SSSD to the releases page and mention SECURITY.md for reporting security issues.